### PR TITLE
use commas to delimit the include statement

### DIFF
--- a/src/sgg_utils/foreup_utils.py
+++ b/src/sgg_utils/foreup_utils.py
@@ -55,7 +55,7 @@ def get_sale(token, course_id, sale_id, include=[]):
     }
 
     if len(include) > 0:
-        included = '?include=' + '&'.join(include)
+        included = '?include=' + ','.join(include)
     else:
         included = ''
 
@@ -79,13 +79,12 @@ def get_booking(token, course_id, teesheet_id, booking_id, include=[]):
     }
 
     if len(include) > 0:
-        included = '?include=' + '&'.join(include)
+        included = '?include=' + ','.join(include)
     else:
         included = ''
 
     bookings_data = []
     r = requests.get(f'{API_URL}/courses/{course_id}/teesheets/{teesheet_id}/bookings/{booking_id}{included}', headers=headers)
-
     try:
         content = json.loads(r.content)
     except json.JSONDecodeError:
@@ -102,7 +101,7 @@ def get_teesheet(token, course_id, teesheet_id, include: list = []):
         'x-authorization': f'Bearer {token}'
     }
     if len(include) > 0:
-        included = '?include=' + '&'.join(include)
+        included = '?include=' + ','.join(include)
     else:
         included = ''
 

--- a/test/test_sgg.py
+++ b/test/test_sgg.py
@@ -68,15 +68,18 @@ def test_sale():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
-    sales = foreup_utils.get_sale(token, SALE_TEST_CASE['COURSE_ID'], SALE_TEST_CASE['SALE_ID'])
+    sales = foreup_utils.get_sale(token, SALE_TEST_CASE['COURSE_ID'], SALE_TEST_CASE['SALE_ID'], include=['items','bookings'])
     assert sales[0]['attributes']['saleTime'] == SALE_TEST_CASE['SALE_TIME']
+    assert sales[0]['relationships'].keys() == {'items', 'bookings'}
 
 def test_booking():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
-    bookings = foreup_utils.get_booking(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], BOOKING_TEST_CASE['BOOKING_ID'], include=['players'])
+    bookings = foreup_utils.get_booking(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], BOOKING_TEST_CASE['BOOKING_ID'], include=['players','sales'])
+    print(bookings)
     assert bookings[0]['attributes']['dateBooked'] == BOOKING_TEST_CASE['DATE_BOOKED']
+    assert bookings[0]['relationships'].keys() == {'players', 'sales'}
 
 
 def test_teesheet():
@@ -187,8 +190,9 @@ def test_day_bookings():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
-    bookings = foreup_utils.get_bookings(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], start_date='2023-01-18', include=['players'])
+    bookings = foreup_utils.get_bookings(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], start_date='2023-01-18', include=['players', 'sales'])
     assert len(bookings) == 104
+    assert bookings[0]['relationships'].keys() == {'players', 'sales'}
 
 def test_secret_manager():
     secret = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")


### PR DESCRIPTION
Some of the functions were using `&` instead of `,`, fixed those and added tests. The calls for multiple "include" keys would fail, only returning the first supplied.