### PR TITLE
refactor results of getter functions to return json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name='sgg_utils'
-version = '0.0.4'
+version = '0.0.5'
 authors = [
   { name="Michael Futch", email="michael.d.futch@gmail.com" },
 ]

--- a/src/sgg_utils/foreup_utils.py
+++ b/src/sgg_utils/foreup_utils.py
@@ -59,7 +59,6 @@ def get_sale(token, course_id, sale_id, include=[]):
     else:
         included = ''
 
-    sales_data = []
     r = requests.get(f'{API_URL}/courses/{course_id}/sales/{sale_id}{included}', headers=headers)
 
     try:
@@ -67,10 +66,7 @@ def get_sale(token, course_id, sale_id, include=[]):
     except json.JSONDecodeError:
         logging.error(f'Error: {r.status_code}')
 
-    if r.status_code == 200 and len(content['data']) > 0:
-        sales_data.append(content['data'])
-
-    return sales_data
+    return content
 
 def get_booking(token, course_id, teesheet_id, booking_id, include=[]):
     headers = {
@@ -83,17 +79,13 @@ def get_booking(token, course_id, teesheet_id, booking_id, include=[]):
     else:
         included = ''
 
-    bookings_data = []
     r = requests.get(f'{API_URL}/courses/{course_id}/teesheets/{teesheet_id}/bookings/{booking_id}{included}', headers=headers)
     try:
         content = json.loads(r.content)
     except json.JSONDecodeError:
         logging.error(f'Error: {r.status_code}')
 
-    if r.status_code == 200 and len(content['data']) > 0:
-        bookings_data.append(content['data'])
-
-    return bookings_data
+    return content
 
 def get_teesheet(token, course_id, teesheet_id, include: list = []):
     headers = {
@@ -267,7 +259,7 @@ def get_bookings(token, course_id, teesheet_id, start_date, end_date = None, lim
         ed = end_date
 
     index = 0
-    bookings_data = []
+    bookings_data = {'data': [], 'included': []}
 
     cont = True
     while cont:
@@ -282,7 +274,8 @@ def get_bookings(token, course_id, teesheet_id, start_date, end_date = None, lim
 
         # Check that there is content
         if r.status_code == 200 and len(content['data']) > 0:
-            bookings_data.extend(content['data'])
+            bookings_data['data'].extend(content['data'])
+            bookings_data['included'].extend(content['included'])
 
             ## end if results are less than limit, else increment the index
             if len(content['data']) < limit:
@@ -318,7 +311,7 @@ def get_sales(token, course_id, start_date, end_date = None, limit=100, include=
         ed = end_date
 
     index = 0
-    sales_data = []
+    sales_data = {'data': [], 'included': []}
 
     cont = True
     while cont:
@@ -333,8 +326,8 @@ def get_sales(token, course_id, start_date, end_date = None, limit=100, include=
 
         # Check that there is content
         if r.status_code == 200 and len(content['data']) > 0:
-            sales_data.extend(content['data'])
-
+            sales_data['data'].extend(content['data'])
+            sales_data['included'].extend(content['included'])
             ## end if results are less than limit, else increment the index
             if len(content['data']) < limit:
                 print(f"No more results for {course_id}")
@@ -355,13 +348,13 @@ def get_customers(token, course_id, limit = 100, testing=False):
     }
     start = 0
     cont = True
-    customers = []
+    customers = {'data': []}
     while cont:
         r = requests.get(f'{API_URL}/courses/{course_id}/customers?start={start}&limit={limit}', headers=headers)
         content = json.loads(r.content)
 
         if r.status_code == 200 and len(content['data']) > 0:
-            customers.extend(content['data'])
+            customers['data'].extend(content['data'])
             if len(content['data']) < limit:
                 cont = False
             else:

--- a/test/test_sgg.py
+++ b/test/test_sgg.py
@@ -71,17 +71,17 @@ def test_sale():
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     sales = foreup_utils.get_sale(token, SALE_TEST_CASE['COURSE_ID'], SALE_TEST_CASE['SALE_ID'], include=['items','bookings'])
-    assert sales[0]['attributes']['saleTime'] == SALE_TEST_CASE['SALE_TIME']
-    assert sales[0]['relationships'].keys() == {'items', 'bookings'}
+    print(sales)
+    assert sales['data']['attributes']['saleTime'] == SALE_TEST_CASE['SALE_TIME']
+    assert sales['data']['relationships'].keys() == {'items', 'bookings'}
 
 def test_booking():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     bookings = foreup_utils.get_booking(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], BOOKING_TEST_CASE['BOOKING_ID'], include=['players','sales'])
-    print(bookings)
-    assert bookings[0]['attributes']['dateBooked'] == BOOKING_TEST_CASE['DATE_BOOKED']
-    assert bookings[0]['relationships'].keys() == {'players', 'sales'}
+    assert bookings['data']['attributes']['dateBooked'] == BOOKING_TEST_CASE['DATE_BOOKED']
+    assert bookings['data']['relationships'].keys() == {'players', 'sales'}
 
 
 def test_teesheet():
@@ -98,7 +98,6 @@ def test_seasons():
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     seasons = foreup_utils.get_all_seasons(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'])
-    #print(seasons['data'][0])
     assert seasons['data'] is not None
     assert len(seasons['data']) > 0
 
@@ -164,7 +163,6 @@ def test_pricing():
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     pricing = foreup_utils.get_pricing(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], BOOKING_TEST_CASE['BOOKING_ID'])
-    print(pricing)
     assert pricing['data'] is not None
     assert len(pricing) > 0
 
@@ -174,8 +172,6 @@ def test_price_class():
     token = foreup_utils.get_token(username, password)
     price_class = foreup_utils.get_price_class(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['PRICE_CLASS_ID'])
     courses = foreup_utils.get_courses(token)
-    print(courses[BOOKING_TEST_CASE['COURSE_ID']])
-    print(price_class)
     assert price_class['data'] is not None
     assert len(price_class) > 0
 
@@ -188,13 +184,13 @@ def test_price_class():
 #     assert bookings is not None
 #     assert len(bookings) > 0
     
-def test_day_bookings():
+def test_bookings():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     bookings = foreup_utils.get_bookings(token, BOOKING_TEST_CASE['COURSE_ID'], BOOKING_TEST_CASE['TEESHEET_ID'], start_date='2023-01-18', include=['players', 'sales'])
-    assert len(bookings) == 104
-    assert bookings[0]['relationships'].keys() == {'players', 'sales'}
+    assert len(bookings['data']) == 104
+    assert bookings['data'][0]['relationships'].keys() == {'players', 'sales'}
 
 def test_secret_manager():
     secret = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
@@ -209,16 +205,16 @@ def test_get_customers():
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     customers = foreup_utils.get_customers(token, '21561', testing=True)
-    assert customers[0]['type'] == 'customers'
-    assert len(customers) > 0
+    assert customers['data'][0]['type'] == 'customers'
+    assert len(customers['data']) > 0
 
 def test_get_sales():
     username = 'mfutch78@gmail.com'
     password = cloud_utils.access_secret_version("593748364912", "FOREUP_MFUTCH", "latest")
     token = foreup_utils.get_token(username, password)
     sales = foreup_utils.get_sales(token, '21561', start_date='2023-01-18', end_date='2023-01-19', include=['items','bookings'])
-    assert sales[0]['type'] == 'sales'
-    assert sales[0]['relationships'].keys() == {'items', 'bookings'}
+    assert sales['data'][0]['type'] == 'sales'
+    assert sales['data'][0]['relationships'].keys() == {'items', 'bookings'}
 
 def test_get_items():
     username = 'mfutch78@gmail.com'


### PR DESCRIPTION
Refactor sales/bookings functions to return json of lists rather than json because in order to get the detailed sales info we need to capture the "included" json data in get_sale and get_sales, not just the relationships because the id in the items relationship is the sales_item_id, not the item_id.