### PR TITLE
Sale sleep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name='sgg_utils'
-version = '0.0.7'
+version = '0.1.01'
 authors = [
   { name="Michael Futch", email="michael.d.futch@gmail.com" },
 ]

--- a/src/sgg_utils/foreup_utils.py
+++ b/src/sgg_utils/foreup_utils.py
@@ -69,6 +69,7 @@ def get_sale(token, course_id, sale_id, include=[]):
         logging.error(f'Trying again...')
         time.sleep(5)
         r = requests.get(f'{API_URL}/courses/{course_id}/sales/{sale_id}{included}', headers=headers)
+        logging.error(f'Retry status: {r.status_code}')
         content = json.loads(r.content)
 
     return content

--- a/src/sgg_utils/foreup_utils.py
+++ b/src/sgg_utils/foreup_utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 from datetime import datetime, timedelta
 from sgg_utils import cloud_utils
+import time
 
 API_URL = 'https://api.foreupsoftware.com/api_rest/index.php'
 
@@ -65,6 +66,10 @@ def get_sale(token, course_id, sale_id, include=[]):
         content = json.loads(r.content)
     except json.JSONDecodeError:
         logging.error(f'Error: {r.status_code}')
+        logging.error(f'Trying again...')
+        time.sleep(5)
+        r = requests.get(f'{API_URL}/courses/{course_id}/sales/{sale_id}{included}', headers=headers)
+        content = json.loads(r.content)
 
     return content
 


### PR DESCRIPTION
Occasional lags in foreup system means our webhook process tries to find a sale that isn't in the foreup data yet, added a sleep of 5 seconds if this happens, then a retry. 